### PR TITLE
arm64: Encode MOVZ

### DIFF
--- a/arm64_tests/move.clif
+++ b/arm64_tests/move.clif
@@ -1,0 +1,33 @@
+function %a() -> i64 {
+ebb0:
+    v0 = iconst.i64 1 ; bin: d2800020
+    return v0
+}
+
+function %b() -> i64 {
+ebb0:
+    ; (2 ^ 16) - 1
+    v0 = iconst.i64 65535 ; bin: d29fffe0
+    return v0
+}
+
+function %c() -> i64 {
+ebb0:
+    ; ((2 ^ 16) - 1) << 16
+    v0 = iconst.i64 4294901760 ; bin: d2bfffe0
+    return v0
+}
+
+function %d() -> i64 {
+ebb0:
+    ; ((2 ^ 16) - 1) << 32
+    v0 = iconst.i64 281470681743360 ; bin: d2dfffe0
+    return v0
+}
+
+function %e() -> i64 {
+ebb0:
+    ; ((2 ^ 16) - 1) << 48
+    v0 = iconst.i64 18446462598732840960 ; bin: d2dfffe0
+    return v0
+}

--- a/cranelift-codegen/src/isa/arm64/inst.rs
+++ b/cranelift-codegen/src/isa/arm64/inst.rs
@@ -1268,6 +1268,23 @@ fn enc_cbr(op_31_24: u32, off_18_0: u32, op_4: u32, cond: u32) -> u32 {
     (op_31_24 << 24) | (off_18_0 << 5) | (op_4 << 4) | cond
 }
 
+const MOVE_WIDE_FIXED: u32 = 0x92800000;
+
+#[repr(u32)]
+enum MoveWideOpcode {
+    MOVZ = 0b10,
+}
+
+// TODO: Pass imm_shift / imm16 in a struct?
+fn enc_move_wide(opc: MoveWideOpcode, rd: Reg, imm_shift: u8, imm16: u16) -> u32 {
+    assert!(imm_shift <= 0b11);
+    MOVE_WIDE_FIXED
+        | (opc as u32) << 29
+        | (imm_shift as u32) << 21
+        | (imm16 as u32) << 5
+        | machreg_to_gpr(rd)
+}
+
 impl<CS: CodeSink> MachInstEmit<CS> for Inst {
     fn emit(&self, sink: &mut CS) {
         match self {
@@ -1389,7 +1406,9 @@ impl<CS: CodeSink> MachInstEmit<CS> for Inst {
                 /*ref*/ mem: _,
                 ..
             } => unimplemented!(),
-            &Inst::MovZ { rd: _, .. } => unimplemented!(),
+            &Inst::MovZ { rd, imm } => {
+                sink.put4(enc_move_wide(MoveWideOpcode::MOVZ, rd, imm.shift, imm.bits))
+            }
             &Inst::Jump { ref dest } => {
                 // TODO: differentiate between as_off26() returning `None` for
                 // out-of-range vs. not-yet-finalized. The latter happens when we


### PR DESCRIPTION
For the Add instruction, the zero register encoding is used for
SP. So delete the use of Add from lower_constant.

I think we should discuss the general design of the binary emission parts of the file. I think it's good to get some parts working first, but maybe there is a more structured approach once things are further along.
