### PR TITLE
arm64: Add support for MOVN

### DIFF
--- a/arm64_tests/move.clif
+++ b/arm64_tests/move.clif
@@ -31,3 +31,38 @@ ebb0:
     v0 = iconst.i64 18446462598732840960 ; bin: d2dfffe0
     return v0
 }
+
+function %f() -> i64 {
+ebb0:
+    ; ~1
+    v0 = iconst.i64 18446744073709551614 ; bin: 92800020
+    return v0
+}
+
+function %g() -> i64 {
+ebb0:
+    ; ~((2 ^ 16) - 1)
+    v0 = iconst.i64 18446744073709486080 ; bin: 929fffe0
+    return v0
+}
+
+function %h() -> i64 {
+ebb0:
+    ; ~(((2 ^ 16) - 1) << 16)
+    v0 = iconst.i64 18446744069414649855 ; bin: 92bfffe0
+    return v0
+}
+
+function %i() -> i64 {
+ebb0:
+    ; ~(((2 ^ 16) - 1) << 32)
+    v0 = iconst.i64 18446462603027808255 ; bin: 92dfffe0
+    return v0
+}
+
+function %j() -> i64 {
+ebb0:
+    ; ~(((2 ^ 16) - 1) << 48)
+    v0 = iconst.i64 281474976710655 ; bin: 92ffffe0
+    return v0
+}

--- a/cranelift-codegen/src/isa/arm64/lower.rs
+++ b/cranelift-codegen/src/isa/arm64/lower.rs
@@ -339,9 +339,12 @@ fn lower_address<'a>(ctx: Ctx<'a>, elem_ty: Type, addends: &[InsnInput], offset:
 }
 
 fn lower_constant<'a>(ctx: Ctx<'a>, rd: Reg, value: u64) {
-    if let Some(imm) = MovZConst::maybe_from_u64(value) {
+    if let Some(imm) = MoveWideConst::maybe_from_u64(value) {
         // 16-bit immediate (shifted by 0, 16, 32 or 48 bits) in MOVZ
         ctx.emit(Inst::MovZ { rd, imm });
+    } else if let Some(imm) = MoveWideConst::maybe_from_u64(!value) {
+        // 16-bit immediate (shifted by 0, 16, 32 or 48 bits) in MOVN
+        ctx.emit(Inst::MovN { rd, imm });
     } else if let Some(imml) = ImmLogic::maybe_from_u64(value) {
         // Weird logical-instruction immediate in ORI using zero register
         ctx.emit(Inst::AluRRImmLogic {


### PR DESCRIPTION
Renames MovZConst to MoveWideConst, so the logic can be shared.