### PR TITLE
arm64: Add CTZ support

### DIFF
--- a/cranelift-codegen/src/isa/arm64/lower.rs
+++ b/cranelift-codegen/src/isa/arm64/lower.rs
@@ -1151,7 +1151,20 @@ fn lower_insn_to_regs<C: LowerCtx<Inst>>(ctx: &mut C, insn: IRInst) {
             ctx.emit(Inst::BitRR { rd, rn, op });
         }
 
-        Opcode::Ctz | Opcode::Popcnt => {
+        Opcode::Ctz => {
+            let rd = output_to_reg(ctx, outputs[0]);
+            let rn = input_to_reg(ctx, inputs[0], NarrowValueMode::None);
+            let op = BitOp::from((Opcode::Bitrev, ty.unwrap()));
+            ctx.emit(Inst::BitRR { rd, rn, op });
+            let op = BitOp::from((Opcode::Clz, ty.unwrap()));
+            ctx.emit(Inst::BitRR {
+                rd,
+                rn: rd.to_reg(),
+                op,
+            });
+        }
+
+        Opcode::Popcnt => {
             // TODO
             unimplemented!()
         }

--- a/filetests/vcode/arm64/bitops.clif
+++ b/filetests/vcode/arm64/bitops.clif
@@ -1,5 +1,18 @@
 test vcode arch=arm64
 
+function %a(i32) -> i32 {
+block0(v0: i32):
+    v1 = bitrev v0
+    return v1
+}
+
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: rbit w0, w0
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
 function %a(i64) -> i64 {
 block0(v0: i64):
     v1 = bitrev v0
@@ -9,6 +22,19 @@ block0(v0: i64):
 ; check: stp fp, lr, [sp, #-16]!
 ; nextln: mov fp, sp
 ; nextln: rbit x0, x0
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %b(i32) -> i32 {
+block0(v0: i32):
+    v1 = clz v0
+    return v1
+}
+
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: clz w0, w0
 ; nextln: mov sp, fp
 ; nextln: ldp fp, lr, [sp], #16
 ; nextln: ret
@@ -26,6 +52,19 @@ block0(v0: i64):
 ; nextln: ldp fp, lr, [sp], #16
 ; nextln: ret
 
+function %c(i32) -> i32 {
+block0(v0: i32):
+    v1 = cls v0
+    return v1
+}
+
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: cls w0, w0
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
 function %c(i64) -> i64 {
 block0(v0: i64):
     v1 = cls v0
@@ -35,6 +74,34 @@ block0(v0: i64):
 ; check: stp fp, lr, [sp, #-16]!
 ; nextln: mov fp, sp
 ; nextln: cls x0, x0
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %d(i32) -> i32 {
+block0(v0: i32):
+    v1 = ctz v0
+    return v1
+}
+
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: rbit w0, w0
+; nextln: clz w0, w0
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %d(i64) -> i64 {
+block0(v0: i64):
+    v1 = ctz v0
+    return v1
+}
+
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: rbit x0, x0
+; nextln: clz x0, x0
 ; nextln: mov sp, fp
 ; nextln: ldp fp, lr, [sp], #16
 ; nextln: ret


### PR DESCRIPTION
This lowers to RBIT + CLZ.

@cfallin What do you think about removing the stack related instructions in the test and just checking for the relevant instructions? The tests are getting quite repetitive now.